### PR TITLE
Added option to filter out islands below a certain size

### DIFF
--- a/breizorro/breizorro.py
+++ b/breizorro/breizorro.py
@@ -149,7 +149,7 @@ def main():
                          help='List of islands to remove from input mask. e.g. --remove-islands 1 18 20 20h10m13s,14d15m20s')
     parser.add_argument('--extract-islands', dest='extract_isl', metavar='N|COORD', type=str, nargs='+',
                          help='List of islands to extract from input mask. e.g. --extract-islands 1 18 20 20h10m13s,14d15m20s')
-    parser.add_argument('--minimum-size', dest='minsize', default=False,
+    parser.add_argument('--minimum-size', dest='minsize', type=int,
                         help='Remove islands that have areas fewer than or equal to the specified number of pixels')
     parser.add_argument('--make-binary', action="store_true",
                          help='Replace all island numbers with 1')
@@ -289,7 +289,7 @@ def main():
         mask_image = mask_image != 0
         island_labels, num_features = label(mask_image)
         island_areas = numpy.array(scipy.ndimage.sum(mask_image,island_labels, numpy.arange(island_labels.max()+1)))
-        min_mask = island_areas >= int(args.minsize)
+        min_mask = island_areas >= args.minsize
         mask_image = min_mask[island_labels.ravel()].reshape(island_labels.shape)
 
     if args.make_binary:


### PR DESCRIPTION
Added this option:

```
  --minimum-size MINSIZE
                        Remove islands that have areas fewer than or equal to the specified number of
                        pixels
```

to remove islands below a certain size. This can be useful when you are chasing low-level diffuse emission by running breizorro on a residual image but want to filter our noise spikes or compact source artefacts.